### PR TITLE
A ComposablePerformer Test

### DIFF
--- a/library/src/androidTest/java/com/google/android/material/motion/runtime/ComposablePlanTest.java
+++ b/library/src/androidTest/java/com/google/android/material/motion/runtime/ComposablePlanTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2016 The Material Motion Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.material.motion.runtime;
+
+import android.test.AndroidTestCase;
+import android.widget.TextView;
+
+public class ComposablePlanTest extends AndroidTestCase {
+
+  private static Scheduler scheduler;
+  private static TextView textView;
+  private Transaction transaction;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    scheduler = new Scheduler();
+    textView = new TextView(getContext());
+    transaction = new Transaction();
+  }
+
+  public void testComposablePlan() {
+    // add the root plan and have it delegate to the leaf plan
+    RootPlan rootPlan = new RootPlan("rootPlan");
+    transaction.addNamedPlan(rootPlan, "rootPlan", textView);
+    scheduler.commitTransaction(transaction);
+
+    assertTrue(textView.getText().equals("leafPlan"));
+  }
+
+  private class RootPlan extends Plan {
+
+    private String text;
+
+    private RootPlan(String text) {
+      this.text = text;
+    }
+
+    @Override
+    public Class<? extends Performer> getPerformerClass() {
+      return ComposablePerformer.class;
+    }
+  }
+
+  private static class LeafPlan extends Plan {
+
+    private String text;
+
+    private LeafPlan(String text) {
+      this.text = text;
+    }
+
+    @Override
+    public Class<? extends Performer> getPerformerClass() {
+      return LeafPlanPerformer.class;
+    }
+  }
+
+  public static class LeafPlanPerformer extends Performer implements Performer.PlanPerformance {
+
+    @Override
+    public void addPlan(Plan plan) {
+      LeafPlan leafPlan = (LeafPlan) plan;
+      TextView target = getTarget();
+      target.setText(leafPlan.text);
+    }
+  }
+
+  public static class ComposablePerformer extends Performer implements Performer.ComposablePerformance, Performer.PlanPerformance {
+
+    private ComposablePerformanceCallback callback;
+
+    @Override
+    public void setComposablePerformanceCallback(ComposablePerformanceCallback callback) {
+      this.callback = callback;
+    }
+
+    @Override
+    public void addPlan(Plan plan) {
+      // immediately delegate the actual work of changing the text view to the leaf plan
+      this.callback.transact(new Work() {
+        @Override
+        public void work(Transaction transaction) {
+          LeafPlan leafPlan = new LeafPlan("leafPlan");
+          transaction.addNamedPlan(leafPlan, "leafPlan", textView);
+          scheduler.commitTransaction(transaction);
+        }
+      });
+    }
+  }
+}


### PR DESCRIPTION
I _believe_ this tests out ComposablePerformance.

The main meat of the test is:

```
        public void work(Transaction transaction) {
          LeafPlan leafPlan = new LeafPlan("leafPlan");
          transaction.addNamedPlan(leafPlan, "leafPlan", textView);
          scheduler.commitTransaction(transaction);
        }
```
- https://codecov.io/github/seanoshea/material-motion-runtime-android/commit/9c03a82dd7b2f6fa18352ca21e2084e4c7fd21b0 is the corresponding code coverage associated with this change.
- http://codereview.cc/D1488 is the original code review for adding ComposablePerformance.
- https://github.com/material-motion/material-motion-runtime-android/issues/21 for the original issue.
- https://material-motion.gitbooks.io/material-motion-starmap/content/specifications/runtime/performer-composition.html for the spec.

cc @pingpongboss @jverkoey for review.
