### PR TITLE
Adding plans directly to the scheduler

### DIFF
--- a/library/src/androidTest/java/com/google/android/material/motion/runtime/SchedulerTest.java
+++ b/library/src/androidTest/java/com/google/android/material/motion/runtime/SchedulerTest.java
@@ -111,6 +111,12 @@ public class SchedulerTest extends AndroidTestCase {
     assertTrue(scheduler.getState() == Scheduler.IDLE);
   }
 
+  public void testAddingPlansDirectlyToScheduler() {
+    scheduler.addPlan(new NeverEndingDelegatedPlan("delegated"), textView);
+
+    assertTrue(scheduler.getState() == Scheduler.ACTIVE);
+  }
+
   private static class StandardPlan extends Plan {
 
     private final String text;

--- a/library/src/androidTest/java/com/google/android/material/motion/runtime/SchedulerTest.java
+++ b/library/src/androidTest/java/com/google/android/material/motion/runtime/SchedulerTest.java
@@ -111,10 +111,16 @@ public class SchedulerTest extends AndroidTestCase {
     assertTrue(scheduler.getState() == Scheduler.IDLE);
   }
 
-  public void testAddingPlansDirectlyToScheduler() {
+  public void testAddingPlanDirectlyToScheduler() {
     scheduler.addPlan(new NeverEndingDelegatedPlan("delegated"), textView);
 
     assertTrue(scheduler.getState() == Scheduler.ACTIVE);
+  }
+
+  public void testAddingStandardPlanDirectlyToScheduler() {
+    scheduler.addPlan(new StandardPlan("standard"), textView);
+
+    assertTrue(textView.getText().equals(" standard"));
   }
 
   private static class StandardPlan extends Plan {

--- a/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
+++ b/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
@@ -164,7 +164,7 @@ public final class Scheduler {
    * Adds a plan to this scheduler.
    * @param plan the {@link Plan} to add to the scheduler.
    * @param target the target on which the plan will operate.
-  */
+   */
   public void addPlan(Plan plan, Object target) {
     PlanInfo planInfo = new PlanInfo();
     planInfo.target = target;

--- a/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
+++ b/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
@@ -147,7 +147,9 @@ public final class Scheduler {
    * Commits the given {@link Transaction}. Each {@link PlanInfo} is committed in the context of
    * its target, called a {@link TargetScope}. Each TargetScope ensures that only one instance of a
    * specific type of Performer is created.
-   * @deprecated
+   * @deprecated  Post version 1.0, plans should be added directly to the Scheduler instead of using Transactions. </br>
+   *              This will be removed in the next version </br>
+   *              use {@link #addPlan()} on the Scheduler instead
    */
   @Deprecated
   public void commitTransaction(Transaction transaction) {
@@ -158,6 +160,11 @@ public final class Scheduler {
     }
   }
 
+  /**
+   * Adds a plan to this scheduler. Uses {@link PlanInfo} to join the plan and the target together.
+   * @param plan the {@link Plan} to add to the scheduler.
+   * @param target the target on which the plan will operate.
+     */
   public void addPlan(Plan plan, Object target) {
     PlanInfo planInfo = new PlanInfo();
     planInfo.target = target;

--- a/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
+++ b/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
@@ -143,13 +143,15 @@ public final class Scheduler {
     listeners.remove(listener);
   }
 
+
+
   /**
    * Commits the given {@link Transaction}. Each {@link PlanInfo} is committed in the context of
    * its target, called a {@link TargetScope}. Each TargetScope ensures that only one instance of a
    * specific type of Performer is created.
-   * @deprecated  Post version 1.0, plans should be added directly to the Scheduler instead of using Transactions. </br>
-   *              This will be removed in the next version </br>
-   *              use {@link #addPlan()} on the Scheduler instead
+   * @deprecated  Plans should be added directly to the Scheduler instead of using Transactions. <br />
+   *              This will be removed in the next version <br />
+   *              use {@link com.google.android.material.motion.runtime.Scheduler#addPlan(Plan, Object)} on the Scheduler instead
    */
   @Deprecated
   public void commitTransaction(Transaction transaction) {
@@ -168,7 +170,7 @@ public final class Scheduler {
   public void addPlan(Plan plan, Object target) {
     PlanInfo planInfo = new PlanInfo();
     planInfo.target = target;
-    planInfo.plan = plan;
+    planInfo.plan = plan.clone();
     getTargetScope(target).commitPlan(planInfo);
   }
 

--- a/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
+++ b/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
@@ -143,8 +143,6 @@ public final class Scheduler {
     listeners.remove(listener);
   }
 
-
-
   /**
    * Commits the given {@link Transaction}. Each {@link PlanInfo} is committed in the context of
    * its target, called a {@link TargetScope}. Each TargetScope ensures that only one instance of a
@@ -166,7 +164,7 @@ public final class Scheduler {
    * Adds a plan to this scheduler.
    * @param plan the {@link Plan} to add to the scheduler.
    * @param target the target on which the plan will operate.
-     */
+  */
   public void addPlan(Plan plan, Object target) {
     PlanInfo planInfo = new PlanInfo();
     planInfo.target = target;

--- a/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
+++ b/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
@@ -147,13 +147,22 @@ public final class Scheduler {
    * Commits the given {@link Transaction}. Each {@link PlanInfo} is committed in the context of
    * its target, called a {@link TargetScope}. Each TargetScope ensures that only one instance of a
    * specific type of Performer is created.
+   * @deprecated
    */
+  @Deprecated
   public void commitTransaction(Transaction transaction) {
     List<PlanInfo> plans = transaction.getPlans();
     for (int i = 0, count = plans.size(); i < count; i++) {
       PlanInfo plan = plans.get(i);
       getTargetScope(plan.target).commitPlan(plan);
     }
+  }
+
+  public void addPlan(Plan plan, Object target) {
+    PlanInfo planInfo = new PlanInfo();
+    planInfo.target = target;
+    planInfo.plan = plan;
+    getTargetScope(target).commitPlan(planInfo);
   }
 
   private TargetScope getTargetScope(Object target) {

--- a/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
+++ b/library/src/main/java/com/google/android/material/motion/runtime/Scheduler.java
@@ -163,7 +163,7 @@ public final class Scheduler {
   }
 
   /**
-   * Adds a plan to this scheduler. Uses {@link PlanInfo} to join the plan and the target together.
+   * Adds a plan to this scheduler.
    * @param plan the {@link Plan} to add to the scheduler.
    * @param target the target on which the plan will operate.
      */

--- a/library/src/main/java/com/google/android/material/motion/runtime/Transaction.java
+++ b/library/src/main/java/com/google/android/material/motion/runtime/Transaction.java
@@ -44,7 +44,11 @@ public final class Transaction {
 
   /**
    * Adds a {@link Plan} to this Transaction, targeting the given object.
+   * @deprecated  Plans should be added directly to the Scheduler instead of using Transactions. <br />
+   *              This will be removed in the next version of the runtime <br />
+   *              use {@link com.google.android.material.motion.runtime.Scheduler#addPlan(Plan, Object)} on the Scheduler instead
    */
+  @Deprecated
   public void addPlan(Plan plan, Object target) {
     PlanInfo info = new PlanInfo();
     info.target = target;


### PR DESCRIPTION
I think this is all we need to close out on https://github.com/material-motion/material-motion-runtime-android/issues/35.

I didn't go into adding or removing named plans to and from the scheduler instead of going through the transaction, as I think that can be all handled together in https://github.com/material-motion/material-motion-runtime-android/issues/34

cc @pingpongboss @jverkoey @appsforartists
